### PR TITLE
Maintain log in google tasks note and sync from manual notes

### DIFF
--- a/scripts/gtask.js
+++ b/scripts/gtask.js
@@ -159,7 +159,13 @@ GTD.gtask.updateTask = function(taskListId, parentTask, taskDetails) {
         task.setStatus('needsAction');
         task.setCompleted(null);
     }
-    task.setNotes(taskDetails.notes);
+    var notes;
+    if (taskDetails.keepGTaskNote) {
+        notes = task.getNotes() + '\n' + taskDetails.notes;
+    } else {
+        notes = taskDetails.notes;
+    }
+    task.setNotes(notes);
     var updatedTask = Tasks.Tasks.patch(task, taskListId, task.id);
 };
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -328,10 +328,12 @@ GTD.changeTaskStatus = function(options) {
         var tl = GTD.gtask.getActiveTaskList();
         var timestamp = GTD.getTimeStamp(task.taskDesc);
         var title = task.taskDesc.replace(timestamp + '\n', '');
+        var currentTime = GTD.util.toISO(new Date());
         GTD.gtask.updateTask(tl.taskListId, tl.parentTask, {
             title: title,
-            notes: timestamp + ' moved from [' + task.statusBefore + '] to [' + options.status + ']',
-            status: options.status
+            notes: currentTime + ' moved from [' + task.statusBefore + '] to [' + options.status + ']',
+            status: options.status,
+            keepGTaskNote: true
         });
     }
 };

--- a/scripts/task-thread.js
+++ b/scripts/task-thread.js
@@ -89,6 +89,10 @@ GTD.Task.setColumnWidth = function(table) {
     }
 };
 
+/* Format the table under the cursor to be a certain format based on
+ * types.
+ * TODO(hbhzwj): change the function name, which is a misnomer.
+ */
 GTD.Task.insertNote = function(noteType) {
     var document = DocumentApp.getActiveDocument();
     var cursor = document.getCursor();
@@ -122,6 +126,13 @@ GTD.Task.insertNote = function(noteType) {
 //     var position = doc.newPosition(cell, 0);
 //     doc.setCursor(position);
 // };
+/* Insert a comment in current cursor or to a specific thread.
+ * If insert to a thread, need to input threadHeader, which is the table
+ * element of the thread.
+ *
+ * Note: If you only have taskDesc, you can get its task header by
+ * calling getTaskHeader
+ */
 GTD.Task.insertComment = function(options) {
     if (typeof options === 'undefined') {
       options = {'location': 'cursor'};


### PR DESCRIPTION
There are two improvements of google gtasks sync
- User can add comment directly in google tasks (as long as line doesn't
  start with '#'). When 'sync from google task' is clicked, the script
  will pull all lines that
  1. not empty
  2. doesn't starts with '#'
  3. doesn't contains yyyy-mm-dd hh:MM:SS format timestamps
     and insert a comment in task thread using the lines.
- When user change status in google docs and gtask sync is enabled, the
  notes in google task will not removed, instead, a new status update
  entry will be appended to google tasks note part
